### PR TITLE
fix: Package - make webpack peer dependency optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,11 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -75,5 +75,10 @@
   },
   "peerDependencies": {
     "webpack": "^4.0.0 || ^5.0.0-rc.1"
+  },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
CLI can now runs on projects where webpack is not available (rspack, vite)
