### PR TITLE
fix empty env vars

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -36,9 +36,9 @@ export const agent = (artifactsData, config, args = {}, logger = console) => {
 
   const envVars = getEnvVars();
 
-  // Normalized env vars - merge provided args with env vars
+  // Normalized params - merge provided args with env vars
   // @type {EnvVars}
-  const normalizedEnvVars = {
+  const normalizedParams = {
     slug: args.slug || envVars.slug,
     branch: args.branch || envVars.branch,
     pr: args.pr || envVars.pr,
@@ -54,23 +54,23 @@ export const agent = (artifactsData, config, args = {}, logger = console) => {
     endpoint: envVars.endpoint,
   };
 
-  debug('normalized env vars ', maskObjectProperties(normalizedEnvVars, ['key']));
+  debug('normalized parameters - agent configuration with environmental variables fallback', maskObjectProperties(normalizedParams, ['key']));
 
   const { includeCommitMessage } = config;
 
   const params = {
     agentVersion: packageInfo.version,
 
-    ...normalizedEnvVars,
+    ...normalizedParams,
 
     // Get commit message using git if includeCommitMessage is set and
     // there is no --commit-message argument or RELATIVE_CI_COMMIT_MESSAGE
-    ...includeCommitMessage && !normalizedEnvVars.commitMessage && {
+    ...includeCommitMessage && !normalizedParams.commitMessage && {
       commitMessage: getCommitMessage(),
     },
   };
 
-  debug('Job parameters', maskObjectProperties(params, ['key']));
+  debug('job parameters', maskObjectProperties(params, ['key']));
 
   // Validate parameters
   if (!params.key) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -125,7 +125,7 @@ export function getEnvVars() {
     commit: process.env.RELATIVE_CI_COMMIT,
     commitMessage: process.env.RELATIVE_CI_COMMIT_MESSAGE,
   };
-  debug('custom environment variables', maskObjectProperties(customEnvVars, ['key']));
+  debug('RELATIVE_CI environment variables', maskObjectProperties(customEnvVars, ['key']));
 
   const resolvedEnvVars = {
     key: customEnvVars.key,
@@ -140,7 +140,7 @@ export function getEnvVars() {
     commit: customEnvVars.commit || envCIvars.commit,
     commitMessage: customEnvVars.commitMessage,
   };
-  debug('resolved environment variables', maskObjectProperties(envCIvars, ['key']));
+  debug('resolved environment variables', maskObjectProperties(resolvedEnvVars, ['key']));
 
   return resolvedEnvVars;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,6 +104,19 @@ function resolveSlug(envVars) {
 }
 
 /**
+ * @param {import('env-ci').CiEnv} data
+ * @param {string} key
+ * @returns {string | undefined}
+ */
+function getEnvCIVar(data, key) {
+  if (!data[key]) {
+    return undefined;
+  }
+
+  return data[key];
+}
+
+/**
  * Extract CI environment variables using env-ci and custom fallback env vars
  * @returns {EnvVars}
  */
@@ -131,12 +144,12 @@ export function getEnvVars() {
     key: customEnvVars.key,
     endpoint: customEnvVars.endpoint,
     isCi: envCIvars.isCi, // process.env.CI
-    service: customEnvVars.service || ('service' in envCIvars && envCIvars.service),
+    service: customEnvVars.service || getEnvCIVar(envCIvars, 'service'),
     slug: customEnvVars.slug || resolveSlug(envCIvars),
-    branch: customEnvVars.branch || ('prBranch' in envCIvars && envCIvars.prBranch) || ('branch' in envCIvars && envCIvars.branch),
-    pr: customEnvVars.pr || ('pr' in envCIvars && envCIvars.pr),
-    build: customEnvVars.build || ('build' in envCIvars && envCIvars.build),
-    buildUrl: customEnvVars.buildUrl || ('buildUrl' in envCIvars && envCIvars.buildUrl),
+    branch: customEnvVars.branch || getEnvCIVar(envCIvars, 'prBranch') || getEnvCIVar(envCIvars, 'branch'),
+    pr: customEnvVars.pr || getEnvCIVar(envCIvars, 'pr'),
+    build: customEnvVars.build || getEnvCIVar(envCIvars, 'build'),
+    buildUrl: customEnvVars.buildUrl || getEnvCIVar(envCIvars, 'buildUrl'),
     commit: customEnvVars.commit || envCIvars.commit,
     commitMessage: customEnvVars.commitMessage,
   };


### PR DESCRIPTION
- fix: Commit message argument - do not override _COMMIT_MESSAGE env variable with the git command
- refactor: Update debug entries
- fix: Prevent boolean values for empty env vars
