### PR TITLE
fix(cli): Throw error when stats path is missing

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -90,7 +90,7 @@ export default async function cli(processArgs: Array<string>) {
 
   const { config } = localConfig as { config: Config };
 
-  if (config?.webpack?.stats) {
+  if (!config?.webpack?.stats) {
     throw new Error(LOCALES.CLI_INVALID_CONFIGURATION_ERROR);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected validation logic to ensure the required configuration property is properly checked, improving error handling for missing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->