### PR TITLE
enable oidc publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,5 +177,4 @@ jobs:
       - name: Publish
         run: npm run release
         env:
-          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,5 +178,4 @@ jobs:
         run: npm run release
         env:
           NPM_CONFIG_PROVENANCE: true
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- **build: Upgrade node to v24**
- **test: Run tests on node v24**
- **build: Verdaccio - publish as beta**
- **build: Publish - enable oidc**
- **build: Publish - remove unnecessary provenance flag**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration configuration to remove unused publish environment variables, improving security and reducing maintenance overhead.
  - Streamlined the publish step to rely on existing configuration where appropriate.
  - No user-facing changes; application behavior and features remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->