### PR TITLE
build: Stale issues - increase durations

### DIFF
--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-issue-stale: 30
-          days-before-issue-close: 14
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          stale-issue-message: "This issue is stale because it has been open for 180 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Revised repository issue lifecycle timelines: issues now become stale after 180 days of inactivity (previously 30) and automatically close 30 days after being marked stale (previously 14).
  * Updated notification messages to reflect the new durations.
  * No changes to application features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->