### PR TITLE
Npm aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,3 @@ To get started, follow [RelativeCI Setup guide for rollup-plugin](https://relati
 ## Other agents
 
 - [GitHub action](https://github.com/relative-ci/cli-action)
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "workspaces": [
         "packages/core",
         "packages/cli",
+        "packages/cli-relative-ci",
         "packages/webpack-plugin",
         "packages/rollup-plugin"
       ],
@@ -14174,6 +14175,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/relative-ci": {
+      "resolved": "packages/cli-relative-ci",
+      "link": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -17597,7 +17602,9 @@
         "yargs": "17.7.2"
       },
       "bin": {
-        "relative-ci": "bin/index.js"
+        "relative-ci": "bin/index.js",
+        "relativeci": "bin/index.js",
+        "relci": "bin/index.js"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "29.0.2",
@@ -17615,6 +17622,28 @@
       },
       "engines": {
         "node": ">= 18.0.0"
+      }
+    },
+    "packages/cli-relative-ci": {
+      "name": "relative-ci",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@relative-ci/cli": "5.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cli/aliases/relative-ci": {
+      "version": "5.3.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@relative-ci/cli": "5.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/cli/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "workspaces": [
     "packages/core",
     "packages/cli",
+    "packages/cli-relative-ci",
     "packages/webpack-plugin",
     "packages/rollup-plugin"
   ],

--- a/packages/cli-relative-ci/README.MD
+++ b/packages/cli-relative-ci/README.MD
@@ -1,0 +1,7 @@
+<a href="https://relative-ci.com">
+  <img alt="RelativeCI" src="https://raw.githubusercontent.com/relative-ci/agent/master/assets/relative-ci--logo.png" width="96" />
+</a>
+
+# RelativeCI CLI agent alias
+
+Alias for [`@relative-ci/cli`](https://github.com/relative-ci/agent/tree/master/packages/cli)

--- a/packages/cli-relative-ci/package.json
+++ b/packages/cli-relative-ci/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "relative-ci",
+  "version": "0.0.1",
+  "description": "Alias for @relative-ci/cli — CLI to send bundle stats and CI build information to RelativeCI.",
+  "keywords": [
+    "relative-ci",
+    "webpack",
+    "vitejs",
+    "rspack",
+    "rollup",
+    "bundle-size",
+    "bundle-analyzer",
+    "bundle-stats",
+    "stats",
+    "bundle",
+    "size",
+    "assets",
+    "chunks",
+    "modules"
+  ],
+  "homepage": "https://relative-ci.com/documentation/setup/agent/cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/relative-ci/agent.git",
+    "directory": "packages/cli-relative-ci"
+  },
+  "bugs": {
+    "url": "https://github.com/relative-ci/agent/issues"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@relative-ci/cli": "5.3.3"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,9 @@
   },
   "sideEffects": false,
   "bin": {
-    "relative-ci": "bin/index.js"
+    "relative-ci": "bin/index.js",
+    "relativeci": "bin/index.js",
+    "relci": "bin/index.js"
   },
   "scripts": {
     "build": "npm run clean && tsc && rollup -c && npm run build-type",

--- a/verdaccio.yaml
+++ b/verdaccio.yaml
@@ -1,5 +1,8 @@
 storage: .verdaccio-storage
 packages:
+  'relative-ci':
+    access: $all
+    publish: $anonymous
   '@relative-ci/*':
     access: $all
     publish: $anonymous


### PR DESCRIPTION
1. Adds `relci` and `relativeci` aliases for `relative-ci`
2. Publish `relative-ci` to prevent  unexpected behaviour when running `npx relative-ci` without  an existing installation